### PR TITLE
Detect missing cookiefile option

### DIFF
--- a/src/TorControl/TorControl.php
+++ b/src/TorControl/TorControl.php
@@ -209,7 +209,11 @@ class TorControl
                 break;
 
             case static::AUTH_METHOD_COOKIE:
-                $cookie = file_get_contents($this->options['cookiefile']);
+                $cookieFile = $this->getOption('cookiefile');
+                if (false === $cookieFile) {
+                    throw new \Exception('You must set a cookiefile option');
+                }
+                $cookie = file_get_contents($cookieFile);
 
                 $this->executeCommand('AUTHENTICATE ' . bin2hex($cookie));
                 break;


### PR DESCRIPTION
Hi,

I just discovered that TorControl doesn't handle missing cookiefile option, as it already does for password. This pull request fixes that, and throws an exception if no cookiefile is set.

Cheers