### PR TITLE
Updated README example to be working

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ $tc = new TorControl\TorControl(
     array(
         'server' => 'localhost',
         'port'   => 9051,
-        'password' => 'MySecr3tPassw0rd'
+        'password' => 'MySecr3tPassw0rd',
+        'authmethod' => 1
     )
 );
+
+$tc->connect();
 
 $tc->authenticate();
 


### PR DESCRIPTION
I had to dig in to the code to figure out why I was getting Not connected message. Turns out autodetect does not work very well therefore authmethod => 1 is requiredf or a more reliable means of connection. 

The example was also missing $tc->connect() call which is require in order to do $tc->authenticate().