### PR TITLE
Fix error in the readme; `server` should be `hostname`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ require 'vendor/autoload.php';
 // Connect to the TOR server using password authentication
 $tc = new TorControl\TorControl(
     array(
-        'server' => 'localhost',
-        'port'   => 9051,
+        'hostname' => 'localhost',
+        'port'     => 9051,
         'password' => 'MySecr3tPassw0rd',
         'authmethod' => 1
     )


### PR DESCRIPTION
According to
dunglas/php-torcontrol@92e9f890ae66287e8e8b32d99bf9177cf59d05d8, when
invoking `connect()` the method checks for a `hostname`, not a `server`
key in the argument array. The readme should match this usage so as to
avoid likely confusion (and an unpleasant `IOError` exception). See line
number 174 at the above-mentioned commit for the exact details.