### PR TITLE
Fixes #7: Support multi-line replies from Tor.

### DIFF
--- a/src/TorControl/TorControl.php
+++ b/src/TorControl/TorControl.php
@@ -261,7 +261,13 @@ class TorControl
                     $last_separator = $separator;
                 }
 
-                if (!$multiline) {
+                if ($multiline) {
+                    $data[] = array(
+                        'code' => $last_code,
+                        'separator' => $last_separator,
+                        'message' => $line
+                    );
+                } else {
                     if ($code === false || $separator === false) {
                         $e = new Exception\ProtocolError('Bad response format');
                         $e->setResponse($response);
@@ -282,16 +288,7 @@ class TorControl
 
                         return $e;
                     }
-                }
 
-
-                if ($multiline) {
-                    $data[] = array(
-                        'code' => $last_code,
-                        'separator' => $last_separator,
-                        'message' => $line
-                    );
-                } else {
                     $data[] = array(
                         'code' => $code,
                         'separator' => $separator,
@@ -299,7 +296,7 @@ class TorControl
                     );
                 }
 
-                if ($separator === ' ') {
+                if (' ' === $separator) {
                     break 2;
                 }
             }

--- a/tests/TorControl/Tests/TorControlTest.php
+++ b/tests/TorControl/Tests/TorControlTest.php
@@ -88,7 +88,7 @@ class TorControlTest extends \PHPUnit_Framework_TestCase
      */
     public function testMultilineReplies()
     {
-        $_cmds = array(
+        $cmds = array(
             'GETINFO version',
             'GETINFO config-file',
             'GETINFO config-text', // this should return a "multiline" reply
@@ -101,20 +101,23 @@ class TorControlTest extends \PHPUnit_Framework_TestCase
         $this->torControl->connect();
         $this->torControl->authenticate();
 
-        foreach ($_cmds as $cmd) {
+        foreach ($cmds as $cmd) {
             $responses[] = $this->torControl->executeCommand($cmd);
         }
 
-        // Assert we got the same number of responses entries as commands sent.
-        // If we do, and there are no exceptions, we can handle multi-line replies.
-        $this->assertEquals(count($_cmds), count($responses));
+        // Assert we got the same number of response entries as commands sent.
+        // If we do, and there are no exceptions, we can handle multiline replies.
+        $this->assertEquals(count($cmds), count($responses));
+
         // Test to ensure multiline reply codes are correctly populated.
+        // (See section 2.3 of the Tor control spec.)
         foreach ($responses[2] as $resp) {
-            $this->assertSame($resp['code'], '250');
-            $this->assertSame($resp['separator'], '+');
+            $this->assertSame('250', $resp['code']);
+            $this->assertSame('+', $resp['separator']);
         }
+
         // And test that we return to normal replies otherwise.
-        $this->assertSame($responses[3][0]['separator'], '-');
+        $this->assertSame('-', $responses[3][0]['separator']);
     }
 
 }


### PR DESCRIPTION
This commit fixes an issue where a `ProtocolError` exception was
prematurely thrown before the end of a multi-line reply from Tor. The
issue was caused by ignoring the multi-line nature of certain replies
from Tor and always assuming single-line replies. This patch addresses
the issue by retaining state information about whether the current line
is a multi-line or single line reply.

This patch also fixes a typo in an error message (`Unknow`-> `Unknown`).

This patch includes unit tests that demonstrate the problem and the fix.